### PR TITLE
Support Error Handling: Forward error to next middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,8 @@ module.exports = opts => {
       // RFC6750 states the access_token MUST NOT be provided
       // in more than one place in a single request.
       if (error) {
-        res.status(400).send();
+        res.status(400);
+        next(new Error("Multiple tokens provided"));
       } else {
         req[reqKey] = token;
         next();


### PR DESCRIPTION
Set status to 400 and forward an error to the next error handler.